### PR TITLE
Export frontmatter in a more useful way [Breaking Change]

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -170,6 +170,9 @@ export async function createMarkdown(options: ResolvedOptions) {
       scriptLines.push(`const frontmatter = ${JSON.stringify(frontmatter)}`)
 
       if (options.exportFrontmatter) {
+        frontmatterExportsLines = [`export const frontmatter = ${JSON.stringify(frontmatter)}`]
+      }
+      if (options.exportFrontmatterProperties) {
         frontmatterExportsLines = Object.entries(frontmatter)
           .map(([key, value]) => {
             if (EXPORTS_KEYWORDS.includes(key))

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -10,6 +10,7 @@ export function resolveOptions(userOptions: Options): ResolvedOptions {
     exposeFrontmatter: true,
     exposeExcerpt: false,
     exportFrontmatter: true,
+    exportFrontmatterProperties: false,
     escapeCodeTagInterpolation: true,
     customSfcBlocks: ['route', 'i18n', 'style'],
     componentOptions: {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,10 +131,19 @@ export interface Options {
 
   /**
    * Export frontmatter in component module
+   * under the frontmatter key
    *
    * @default true
    */
   exportFrontmatter?: boolean
+
+  /**
+   * Export frontmatter in component module
+   * property by property
+   *
+   * @default true
+   */
+  exportFrontmatterProperties?: boolean
 
   /**
    * Add `v-pre` to `<code>` tag to escape curly brackets interpolation


### PR DESCRIPTION
I wanted to do this:
```
const pageSummaries = import.meta.glob('./**/*.md', { eager: true, import: 'frontmatter' })
```
which doesn't work if the frontmatter is destructured to export individual properties and the 'expose' is no help as we want an export outside of the Vue component.

So I added in that behavior and since I think its the more natural and useful usecase I gave it the existing option name `exportFrontmatter`, renaming the old behavior to `exportFrontmatterProperties` - the two behaviors can be used together.